### PR TITLE
fix compatibility issues with current python and numpy versions

### DIFF
--- a/analysis/analyze.py
+++ b/analysis/analyze.py
@@ -868,7 +868,7 @@ def specific_leakage_test(random, callback, keys, LeaksOnly=True, mp=False):
             rdic_pos[c] = numpy.array(rdic_pos[c], dtype=numpy.int64)
 
         # Extract X in correct order
-        X = numpy.asarray([Xglob[k] for k in keys])
+        X = numpy.asarray([Xglob[k.get_bytes().decode().encode()] for k in keys])
         assert type(X) == numpy.ndarray
         assert len(X_labels) == X.shape[1]
 

--- a/analysis/datastub/leaks.py
+++ b/analysis/datastub/leaks.py
@@ -343,6 +343,12 @@ class Key:
         string = f"{label}='{value}'"
         return string
 
+    def __len__(self):
+        # length of the string representing the key
+        return len(self.value.decode())
+
+    def get_bytes(self):
+        return self.value
 
 """
 *************************************************************************

--- a/analysis/rdctest.py
+++ b/analysis/rdctest.py
@@ -290,7 +290,7 @@ class RDC(object):
 
         # compute sigthres level
         level = 10000
-        v = numpy.zeros(level, dtype=numpy.float)
+        v = numpy.zeros(level, dtype=numpy.float64)
         for i in range(0, level):
             a = numpy.random.normal(size=N)
             b = numpy.random.normal(size=N)
@@ -428,10 +428,10 @@ class RDC(object):
 
         # init
         (n1, n2) = (X.size, Y.size)
-        t1 = numpy.ones((n1, 2), dtype=numpy.float)
-        t2 = numpy.ones((n2, 2), dtype=numpy.float)
-        t3 = numpy.ones((n1, k + 1), dtype=numpy.float)
-        t4 = numpy.ones((n2, k + 1), dtype=numpy.float)
+        t1 = numpy.ones((n1, 2), dtype=numpy.float64)
+        t2 = numpy.ones((n2, 2), dtype=numpy.float64)
+        t3 = numpy.ones((n1, k + 1), dtype=numpy.float64)
+        t4 = numpy.ones((n2, k + 1), dtype=numpy.float64)
 
         # normalized rank
         t1[:, 0] = rankdata(X) / float(n1)


### PR DESCRIPTION
Closes #39.

I made these fixes so that DATA can execute all three phases successfully using the environment described in #39. The issue with the key bytes is quite odd, as adding `.decode().encode()` should behave the same es without it. Nevertheless, for me it is only working with this addition.